### PR TITLE
Check if homebrew is installed before downloading

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 
-echo "Installing / Updating Homebrew"
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+if ! type brew > /dev/null
+then
+    echo "Installing Homebrew..."
+    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+fi
 
 echo "Installing / Updating mpv and youtube dl"
 brew install mpv youtube-dl
@@ -21,11 +24,3 @@ echo "Saving to your Applications folder"
 mv Muubii.app /Applications
 
 echo "DONE :)"
-
-echo "Exiting terminal in 3"
-sleep 2
-echo "2"
-sleep 1
-echo "1"
-sleep 1
-exit


### PR DESCRIPTION
Right now, `install.sh` will waste time trying to install Homebrew even if it is installed. I added a check for the `brew` command so that this issue is fixed. I also removed the sleep statements from the bottom because they're unnecessary.