### PR TITLE
Fixed playback controls and some ui improvements

### DIFF
--- a/NativeYoutube.xcodeproj/project.pbxproj
+++ b/NativeYoutube.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		13E02D0A27ABB35E00B4A648 /* VideoPlayerControlsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13E02D0927ABB35E00B4A648 /* VideoPlayerControlsViewModel.swift */; };
+		13E02D0C27ABD2FE00B4A648 /* String+Time.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13E02D0B27ABD2FE00B4A648 /* String+Time.swift */; };
 		C27DD350272C853E00B4DC16 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C27DD34F272C853E00B4DC16 /* ContentView.swift */; };
 		C27DD352272C853F00B4DC16 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C27DD351272C853F00B4DC16 /* Assets.xcassets */; };
 		C27DD355272C853F00B4DC16 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = C27DD354272C853F00B4DC16 /* Preview Assets.xcassets */; };
@@ -49,6 +51,8 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		13E02D0927ABB35E00B4A648 /* VideoPlayerControlsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoPlayerControlsViewModel.swift; sourceTree = "<group>"; };
+		13E02D0B27ABD2FE00B4A648 /* String+Time.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Time.swift"; sourceTree = "<group>"; };
 		C27DD34A272C853E00B4DC16 /* NativeYoutube.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = NativeYoutube.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C27DD34F272C853E00B4DC16 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		C27DD351272C853F00B4DC16 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -188,6 +192,7 @@
 				C27DD36F272C8A6200B4DC16 /* PlayListViewModel.swift */,
 				C27DD376272C8AB900B4DC16 /* SearchViewModel.swift */,
 				C27DD383272C8D9D00B4DC16 /* SettingsViewModel.swift */,
+				13E02D0927ABB35E00B4A648 /* VideoPlayerControlsViewModel.swift */,
 			);
 			path = ViewModels;
 			sourceTree = "<group>";
@@ -206,6 +211,7 @@
 				C27DD372272C8A8900B4DC16 /* Collections+Extension.swift */,
 				C27DD3A9272CB9FD00B4DC16 /* View+Extension.swift */,
 				C27DD3AB272CBA5800B4DC16 /* NSViewRepresentable+Extension.swift */,
+				13E02D0B27ABD2FE00B4A648 /* String+Time.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -379,8 +385,10 @@
 				C27DD386272C8DD100B4DC16 /* Constants.swift in Sources */,
 				C27DD364272C85C400B4DC16 /* MainViewController.swift in Sources */,
 				C27DD3AA272CB9FD00B4DC16 /* View+Extension.swift in Sources */,
+				13E02D0A27ABB35E00B4A648 /* VideoPlayerControlsViewModel.swift in Sources */,
 				C27DD3B1272CBBD500B4DC16 /* LogTextView.swift in Sources */,
 				C27DD384272C8D9D00B4DC16 /* SettingsViewModel.swift in Sources */,
+				13E02D0C27ABD2FE00B4A648 /* String+Time.swift in Sources */,
 				C2A7FC2D274D8572000D6D33 /* VideoPlayerControlsView.swift in Sources */,
 				C2A7FC25274D791D000D6D33 /* VideoPlayerView.swift in Sources */,
 			);
@@ -514,7 +522,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_ASSET_PATHS = "\"NativeYoutube/Preview Content\"";
-				DEVELOPMENT_TEAM = 4538W4A79B;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = NO;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -546,7 +554,7 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 2;
 				DEVELOPMENT_ASSET_PATHS = "\"NativeYoutube/Preview Content\"";
-				DEVELOPMENT_TEAM = 4538W4A79B;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = NO;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/NativeYoutube/ContentView.swift
+++ b/NativeYoutube/ContentView.swift
@@ -15,25 +15,18 @@ struct ContentView: View {
     @StateObject var youtubePlayerViewModel = YoutubePlayerViewModel()
     
     var body: some View {
-        ZStack(alignment: .bottomLeading) {
-            VStack {
-                VStack(alignment: .leading, spacing: 0) {
-                    switch settingsViewModel.currentPage {
-                    case .playlists:
-                        PlayListView()
-                            .environmentObject(playlistViewModel)
-                            .environmentObject(settingsViewModel)
-                            .environmentObject(youtubePlayerViewModel)
-                    case .search:
-                        SearchView()
-                            .environmentObject(searchViewModel)
-                            .environmentObject(settingsViewModel)
-                            .environmentObject(youtubePlayerViewModel)
-
-                    }
-                }
-                Divider()
-                Spacer(minLength: 25)
+        VStack(alignment: .leading, spacing: 0) {
+            switch settingsViewModel.currentPage {
+            case .playlists:
+                PlayListView()
+                    .environmentObject(playlistViewModel)
+                    .environmentObject(settingsViewModel)
+                    .environmentObject(youtubePlayerViewModel)
+            case .search:
+                SearchView()
+                    .environmentObject(searchViewModel)
+                    .environmentObject(settingsViewModel)
+                    .environmentObject(youtubePlayerViewModel)
             }
             BottomBarView()
                 .environmentObject(settingsViewModel)

--- a/NativeYoutube/Extensions/String+Time.swift
+++ b/NativeYoutube/Extensions/String+Time.swift
@@ -1,0 +1,31 @@
+//
+//  String+Time.swift
+//  NativeYoutube
+//
+//  Created by Erik Bautista on 2/3/22.
+//
+
+import Foundation
+
+extension String {
+    init(timeInterval: TimeInterval) {
+        let formatter = DateComponentsFormatter()
+        formatter.unitsStyle = .positional
+        formatter.zeroFormattingBehavior = .pad
+
+        // Hide hour placeholder if there is no hour present
+
+        let hasHour = (timeInterval / (60 * 60)) > 1
+        if hasHour {
+            formatter.allowedUnits = [.hour, .minute, .second]
+        } else {
+            formatter.allowedUnits = [.minute, .second]
+        }
+
+        if let timeString = formatter.string(from: timeInterval) {
+            self.init(timeString)
+        } else {
+            self.init("0:00")
+        }
+    }
+}

--- a/NativeYoutube/Extensions/View+Extension.swift
+++ b/NativeYoutube/Extensions/View+Extension.swift
@@ -18,17 +18,16 @@ extension View {
         window.becomeKey()
         window.isReleasedWhenClosed = false
         window.title = title
-        window.makeKeyAndOrderFront(self)
         window.level = .floating
         if let isTransparent = isTransparent{
             if isTransparent{
                 window.backgroundColor =  .clear
-                window.isOpaque =   false
-                window.styleMask =   .hudWindow
+                window.isOpaque = false
+                window.styleMask = [.hudWindow, .closable]
                 window.isMovableByWindowBackground = true
-                window.makeKeyAndOrderFront(self)
             }
         }
+        window.makeKeyAndOrderFront(self)
         window.setIsVisible(true)
         return window
     }

--- a/NativeYoutube/Extensions/View+Extension.swift
+++ b/NativeYoutube/Extensions/View+Extension.swift
@@ -18,6 +18,7 @@ extension View {
         window.becomeKey()
         window.isReleasedWhenClosed = false
         window.title = title
+        window.makeKeyAndOrderFront(self)
         window.level = .floating
         if let isTransparent = isTransparent{
             if isTransparent{
@@ -25,9 +26,9 @@ extension View {
                 window.isOpaque = false
                 window.styleMask = [.hudWindow, .closable]
                 window.isMovableByWindowBackground = true
+                window.makeKeyAndOrderFront(self)
             }
         }
-        window.makeKeyAndOrderFront(self)
         window.setIsVisible(true)
         return window
     }

--- a/NativeYoutube/Helpers/StatusBarController.swift
+++ b/NativeYoutube/Helpers/StatusBarController.swift
@@ -27,7 +27,7 @@ class StatusBarController {
             statusBarButton.action = #selector(togglePopover(sender:))
             statusBarButton.target = self
         }
-        
+
         eventMonitor = EventMonitor(mask: [.leftMouseDown, .rightMouseDown], handler: mouseEventHandler)
     }
     

--- a/NativeYoutube/ViewModels/VideoPlayerControlsViewModel.swift
+++ b/NativeYoutube/ViewModels/VideoPlayerControlsViewModel.swift
@@ -72,9 +72,8 @@ class VideoPlayerControlsViewModel: ObservableObject {
     @Published var playbackRate: PlaybackRate = .normal
     @Published var isMuted: Bool = false
     @Published var volume: Double = 100
-    @Published var currentDuration: String = "00:00"
     @Published var seekbar: Double = 0
-    @Published var endDuration: TimeInterval = 0.001
+    @Published var duration: TimeInterval = 0.001
 
     init(youtubePlayer: YouTubePlayer) {
         self.youtubePlayer = youtubePlayer
@@ -137,7 +136,7 @@ extension VideoPlayerControlsViewModel {
             .flatMap { [youtubePlayer] in
                 youtubePlayer.durationPublisher
             }
-            .assign(to: \.endDuration, on: self)
+            .assign(to: \.duration, on: self)
             .store(in: &cancellables)
 
         // Bind and observe seek changes if not seeking
@@ -148,14 +147,6 @@ extension VideoPlayerControlsViewModel {
             }
             .filter({ [unowned self] _ in !self.currentlySeeking })
             .assign(to: \.seekbar, on: self)
-            .store(in: &cancellables)
-
-        // Bind and observe current time changes
-
-        appearSubject
-            .flatMap { [unowned self] in self.$seekbar }
-            .map { String(timeInterval: $0) }
-            .assign(to: \.currentDuration, on: self)
             .store(in: &cancellables)
 
         // MARK: - User Input Changes

--- a/NativeYoutube/ViewModels/VideoPlayerControlsViewModel.swift
+++ b/NativeYoutube/ViewModels/VideoPlayerControlsViewModel.swift
@@ -1,0 +1,240 @@
+//
+//  VideoPlayerControlsViewModel.swift
+//  NativeYoutube
+//
+//  Created by Erik Bautista on 2/3/22.
+//
+
+import Combine
+import YouTubePlayerKit
+import Foundation
+
+class VideoPlayerControlsViewModel: ObservableObject {
+
+    enum Input {
+        case onAppear
+        case playVideo
+        case pauseVideo
+        case muteVideo
+        case unmuteVideo
+        case nextVideo
+        case prevVideo
+        case playbackRate(PlaybackRate)
+        case seeking(Bool)
+    }
+
+    func apply(_ input: Input) {
+        switch input {
+        case .onAppear:
+            onAppearSubject.send()
+        case .playVideo:
+            playVideoSubject.send()
+        case .pauseVideo:
+            pauseVideoSubject.send()
+        case .muteVideo:
+            muteVideoSubject.send()
+        case .unmuteVideo:
+            umuteVideoSubject.send()
+        case .nextVideo:
+            nextVideoSubject.send()
+        case .prevVideo:
+            prevVideoSubject.send()
+        case .playbackRate(let rate):
+            playbackRateSubject.send(rate)
+        case .seeking(let seeking):
+            seekingSubject.send(seeking)
+        }
+    }
+
+    // Input Subjects
+
+    private let onAppearSubject = PassthroughSubject<Void, Never>()
+    private let playVideoSubject = PassthroughSubject<Void, Never>()
+    private let pauseVideoSubject = PassthroughSubject<Void, Never>()
+    private let muteVideoSubject = PassthroughSubject<Void, Never>()
+    private let umuteVideoSubject = PassthroughSubject<Void, Never>()
+    private let nextVideoSubject = PassthroughSubject<Void, Never>()
+    private let prevVideoSubject = PassthroughSubject<Void, Never>()
+    private let playbackRateSubject = PassthroughSubject<PlaybackRate, Never>()
+    private let seekingSubject = PassthroughSubject<Bool, Never>()
+
+    private var cancellables = Set<AnyCancellable>()
+
+    // Properties
+
+    private let youtubePlayer: YouTubePlayer
+    private var currentlySeeking = false
+
+    @Published var playbackState: YouTubePlayer.PlaybackState = .unstarted
+    @Published var playbackRate: PlaybackRate = .normal
+    @Published var isMuted: Bool = false
+    @Published var currentDuration: String = "00:00"
+    @Published var seekbar: Double = 0.001
+    @Published var endDuration: TimeInterval = 0.001
+
+    init(youtubePlayer: YouTubePlayer) {
+        self.youtubePlayer = youtubePlayer
+        bindInputs()
+    }
+}
+
+// MARK: - View Model
+
+extension VideoPlayerControlsViewModel {
+    private func bindInputs() {
+
+        let appearSubject = onAppearSubject
+            .eraseToAnyPublisher()
+            .share()
+
+        // Bind and observe playback state changes
+
+        appearSubject
+            .flatMap({ [youtubePlayer] in
+                youtubePlayer.playbackStatePublisher
+            })
+            .assign(to: \.playbackState, on: self)
+            .store(in: &cancellables)
+
+        // Bind and observe playback rate changes
+
+        appearSubject
+            .flatMap { [youtubePlayer] in
+                youtubePlayer.playbackRatePublisher
+            }
+            .map({ $0 < 1.0 ? .slow : $0 == 1.0 ? .normal : .fast })
+            .assign(to: \.playbackRate, on: self)
+            .store(in: &cancellables)
+
+        // Bind and observe mute states
+
+        appearSubject
+            .flatMap { [youtubePlayer] in
+                youtubePlayer.isMutedPublisher()
+            }
+            .replaceError(with: false)
+            .assign(to: \.isMuted, on: self)
+            .store(in: &cancellables)
+
+        // Bind and observe duration changss
+
+        appearSubject
+            .flatMap { [youtubePlayer] in
+                youtubePlayer.durationPublisher
+            }
+            .assign(to: \.endDuration, on: self)
+            .store(in: &cancellables)
+
+        // Bind and observe seek changes if not seeking
+
+        appearSubject
+            .flatMap {[youtubePlayer] in
+                youtubePlayer.currentTimePublisher()
+            }
+            .combineLatest($endDuration)
+            .filter({ [unowned self] _ in !self.currentlySeeking })
+            .map { $0 / $1 }
+            .assign(to: \.seekbar, on: self)
+            .store(in: &cancellables)
+
+        // Bind and observe current time changes
+
+        appearSubject
+            .combineLatest($seekbar, $endDuration)
+            .map {  String(timeInterval: $1 * $2) }
+            .assign(to: \.currentDuration, on: self)
+            .store(in: &cancellables)
+
+        // Bind and observe any user seek changes and handle the input
+
+        appearSubject
+            .combineLatest($seekbar, $endDuration)
+            .filter({ [unowned self] _ in self.currentlySeeking })
+            .map { $1 * $2 }
+            .sink(receiveValue: { [youtubePlayer] in youtubePlayer.seek(to: $0, allowSeekAhead: true) })
+            .store(in: &cancellables)
+
+        // Bind Inputs
+
+        prevVideoSubject
+            .eraseToAnyPublisher()
+            .sink(receiveValue: youtubePlayer.previousVideo)
+            .store(in: &cancellables)
+
+        playVideoSubject
+            .eraseToAnyPublisher()
+            .sink(receiveValue: youtubePlayer.play)
+            .store(in: &cancellables)
+
+        pauseVideoSubject
+            .eraseToAnyPublisher()
+            .sink(receiveValue: youtubePlayer.pause)
+            .store(in: &cancellables)
+
+        muteVideoSubject
+            .eraseToAnyPublisher()
+            .sink(receiveValue: youtubePlayer.mute)
+            .store(in: &cancellables)
+
+        umuteVideoSubject
+            .eraseToAnyPublisher()
+            .sink(receiveValue: youtubePlayer.unmute)
+            .store(in: &cancellables)
+
+        nextVideoSubject
+            .eraseToAnyPublisher()
+            .sink(receiveValue: youtubePlayer.nextVideo)
+            .store(in: &cancellables)
+
+        playbackRateSubject
+            .eraseToAnyPublisher()
+            .map({ ($0 == .slow) ? 0.5 : ($0 == .normal) ? 1.0 : 2.0  })
+            .sink(receiveValue: youtubePlayer.set(playbackRate: ))
+            .store(in: &cancellables)
+
+        seekingSubject
+            .eraseToAnyPublisher()
+            .assign(to: \.currentlySeeking, on: self)
+            .store(in: &cancellables)
+    }
+}
+
+extension VideoPlayerControlsViewModel{
+    enum PlaybackRate: String{
+        case normal = "speedometer"
+        case fast = "hare"
+        case slow = "tortoise"
+    }
+}
+
+
+extension YouTubePlayer {
+    // Allows to observe a value within a time frame.
+    func isMutedPublisher(
+        updateInterval: TimeInterval = 0.5
+    ) -> AnyPublisher<Bool, Never> {
+        Just(
+            .init()
+        )
+        .append(
+            Timer.publish(
+                every: updateInterval,
+                on: .main,
+                in: .common
+            )
+            .autoconnect()
+        )
+        .flatMap { _ in
+            Future { [weak self] promise in
+                self?.isMuted { result in
+                    guard case .success(let muted) = result else {
+                        return
+                    }
+                    promise(.success(muted))
+                }
+            }
+        }
+        .removeDuplicates()
+        .eraseToAnyPublisher()
+    }
+}

--- a/NativeYoutube/ViewModels/YoutubePlayerViewModel.swift
+++ b/NativeYoutube/ViewModels/YoutubePlayerViewModel.swift
@@ -16,6 +16,9 @@ class YoutubePlayerViewModel: ObservableObject {
     func playVideo(url: String){
         currentVideo = YouTubePlayer.init(source: YouTubePlayer.Source.url(url), configuration: YoutubePlayerViewModel.configuration)
         PopupPlayerView(youtubePlayer: currentVideo ?? YoutubePlayerViewModel.exampleVideo)
+            .onExitCommand(perform: {
+                NSApplication.shared.keyWindow?.close()
+            })
             .openNewWindow(isTransparent: true)
     }
     

--- a/NativeYoutube/ViewModels/YoutubePlayerViewModel.swift
+++ b/NativeYoutube/ViewModels/YoutubePlayerViewModel.swift
@@ -16,9 +16,6 @@ class YoutubePlayerViewModel: ObservableObject {
     func playVideo(url: String){
         currentVideo = YouTubePlayer.init(source: YouTubePlayer.Source.url(url), configuration: YoutubePlayerViewModel.configuration)
         PopupPlayerView(youtubePlayer: currentVideo ?? YoutubePlayerViewModel.exampleVideo)
-            .onExitCommand(perform: {
-                NSApplication.shared.keyWindow?.close()
-            })
             .openNewWindow(isTransparent: true)
     }
     

--- a/NativeYoutube/Views/PlayListView/PlayListView.swift
+++ b/NativeYoutube/Views/PlayListView/PlayListView.swift
@@ -13,24 +13,25 @@ struct PlayListView: View {
     @EnvironmentObject var youtubePlayerViewModel: YoutubePlayerViewModel
 
      var body: some View {
-         VStack{
+         Group {
              if playlistViewModel.currentStatus == .unknownError{
                  SomethingWentWrongView()
                      .environmentObject(settingsViewModel)
-             }
-             ScrollView(.vertical, showsIndicators: false){
-                 ForEach(playlistViewModel.videos, id:\.self.title) { vid in
-                     PlaylistRowView(video: vid)
-                         .onTapGesture(count: 2, perform: {
-                             settingsViewModel.playAudioYTDL(url: vid.url, title: vid.title)
-                         })
-                         .contextMenu(ContextMenu(menuItems: {
-                             CustomContextMenuView(videoUrl: vid.url, videoTitle: vid.title)
-                                 .environmentObject(youtubePlayerViewModel)
-                                 .environmentObject(settingsViewModel)
-                         }))
+             } else {
+                 ScrollView(.vertical, showsIndicators: false){
+                     ForEach(playlistViewModel.videos, id:\.self.title) { vid in
+                         PlaylistRowView(video: vid)
+                             .onTapGesture(count: 2, perform: {
+                                 settingsViewModel.playAudioYTDL(url: vid.url, title: vid.title)
+                             })
+                             .contextMenu(ContextMenu(menuItems: {
+                                 CustomContextMenuView(videoUrl: vid.url, videoTitle: vid.title)
+                                     .environmentObject(youtubePlayerViewModel)
+                                     .environmentObject(settingsViewModel)
+                             }))
+                     }.padding()
                  }
-             }.padding()
+             }
          }
          .onAppear {
              playlistViewModel.startFetch()

--- a/NativeYoutube/Views/SearchView/SearchedVideosView.swift
+++ b/NativeYoutube/Views/SearchView/SearchedVideosView.swift
@@ -12,22 +12,23 @@ struct SearchedVideosView: View {
     @EnvironmentObject var settingsViewModel: SettingsViewModel
     @EnvironmentObject var youtubePlayerViewModel: YoutubePlayerViewModel
     var body: some View {
-        LazyVStack{
+        Group{
             if searchViewModel.currentStatus == .unknownError{
                 SomethingWentWrongView()
                     .environmentObject(settingsViewModel)
-            }
-            ForEach(searchViewModel.videos, id:\.self.title) { vid in
-                SearchRowView(video: vid)
-                    .padding(.horizontal)
-                    .onTapGesture(count: 2, perform: {
-                        settingsViewModel.playAudioYTDL(url: vid.url, title: vid.title)
-                    })
-                    .contextMenu(ContextMenu(menuItems: {
-                        CustomContextMenuView(videoUrl: vid.url, videoTitle: vid.title)
-                            .environmentObject(youtubePlayerViewModel)
-                            .environmentObject(settingsViewModel)
-                    }))
+            } else {
+                ForEach(searchViewModel.videos, id:\.self.title) { vid in
+                    SearchRowView(video: vid)
+                        .padding(.horizontal)
+                        .onTapGesture(count: 2, perform: {
+                            settingsViewModel.playAudioYTDL(url: vid.url, title: vid.title)
+                        })
+                        .contextMenu(ContextMenu(menuItems: {
+                            CustomContextMenuView(videoUrl: vid.url, videoTitle: vid.title)
+                                .environmentObject(youtubePlayerViewModel)
+                                .environmentObject(settingsViewModel)
+                        }))
+                }
             }
         }
     }

--- a/NativeYoutube/Views/SharedViews/PopupPlayerView.swift
+++ b/NativeYoutube/Views/SharedViews/PopupPlayerView.swift
@@ -13,9 +13,8 @@ struct PopupPlayerView: View {
     var body: some View {
         VStack{
             VideoPlayerView(youtubePlayer: youtubePlayer)
-//            RoundedRectangle(cornerRadius: 10)
                 .cornerRadius(20)
-            VideoPlayerControlsView(youtubePlayer: youtubePlayer)
+            VideoPlayerControlsView(viewModel: .init(youtubePlayer: youtubePlayer))
                 .padding(.horizontal)
                 .padding(.bottom, 5)
         }

--- a/NativeYoutube/Views/SharedViews/SomethingWentWrongView.swift
+++ b/NativeYoutube/Views/SharedViews/SomethingWentWrongView.swift
@@ -13,7 +13,6 @@ struct SomethingWentWrongView: View {
     var body: some View {
         Group{
             VStack(spacing: 10){
-                Spacer()
                 Text("Something went wrong 🥶")
                     .font(.largeTitle.bold())
                 Text("Check your API credentials...")
@@ -35,8 +34,10 @@ struct SomethingWentWrongView: View {
                             .openNewWindow(with: "Native Youtube Settings", isTransparent: false)
                     }
                 }
+                Spacer()
             }
         }
+        .padding()
     }
 }
 

--- a/NativeYoutube/Views/SharedViews/VideoPlayerControlsView.swift
+++ b/NativeYoutube/Views/SharedViews/VideoPlayerControlsView.swift
@@ -13,59 +13,75 @@ struct VideoPlayerControlsView: View {
     var body: some View {
         HStack{
             Group{
-                VideoPlayerControlsButtonView(title: "Previous video", image: "backward.end")
-                    .onTapGesture {
-                        viewModel.apply(.prevVideo)
-                    }
+                Button(action: {
+                    viewModel.apply(.prevVideo)
+                }, label: {
+                    Label("Previous video", systemImage: "backward.end")
+                })
+                    .buttonStyle(VideoPlayerControlsButtonStyle())
+
                 switch viewModel.playbackState {
                 case .playing:
-                    VideoPlayerControlsButtonView(title: "Pause video", image: "pause")
-                        .onTapGesture {
-                            viewModel.apply(.pauseVideo)
-                        }
+                    Button(action: {
+                        viewModel.apply(.pauseVideo)
+                    }, label: {
+                        Label("Pause video", systemImage: "pause")
+                    })
+                        .buttonStyle(VideoPlayerControlsButtonStyle())
+
                 case .buffering:
                     ProgressView()
                         .controlSize(.small)
                         .padding(6)
 
                 case .paused:
-                    VideoPlayerControlsButtonView(title: "Play video", image: "play")
-                        .onTapGesture {
-                            viewModel.apply(.playVideo)
-                        }
+                    Button(action: {
+                        viewModel.apply(.playVideo)
+                    }, label: {
+                        Label("Play video", systemImage: "play")
+                    })
+                        .buttonStyle(VideoPlayerControlsButtonStyle())
+
                 default:
-                    VideoPlayerControlsButtonView(title: "Play pause video", image: "circle")
-                        .onTapGesture {
-                            viewModel.apply(.playVideo)
-                        }
+                    Button(action: {
+                        viewModel.apply(.playVideo)
+                    }, label: {
+                        Label("Play pause video", systemImage: "circle")
+                    })
+                        .buttonStyle(VideoPlayerControlsButtonStyle())
                 }
 
-                VideoPlayerControlsButtonView(title: "Next video", image: "forward.end")
-                    .onTapGesture {
-                        viewModel.apply(.nextVideo)
-                    }
+                Button(action: {
+                    viewModel.apply(.nextVideo)
+                }, label: {
+                    Label("Next video", systemImage: "forward.end")
+                })
+                    .buttonStyle(VideoPlayerControlsButtonStyle())
             }
 
             Spacer()
 
             Group {
-                Text(viewModel.currentDuration)
+                Text(String(timeInterval: viewModel.seekbar))
 
-                Slider(value: $viewModel.seekbar, in: 0...viewModel.endDuration) {
+                Slider(value: $viewModel.seekbar, in: 0...viewModel.duration) {
                     viewModel.apply(.seeking($0))
                 }
                 .controlSize(.small)
 
-                Text(String(timeInterval: viewModel.endDuration))
+                Text(String(timeInterval: viewModel.duration))
             }
 
             Spacer()
 
             Group{
-                VideoPlayerControlsButtonView(title: "Toggle Mute", image: viewModel.isMuted ? "speaker.slash": "speaker.wave.3")
-                    .onTapGesture {
-                        viewModel.isMuted ? viewModel.apply(.unmuteVideo) : viewModel.apply(.muteVideo)
-                    }
+
+                Button(action: {
+                    viewModel.isMuted ? viewModel.apply(.unmuteVideo) : viewModel.apply(.muteVideo)
+                }, label: {
+                    Label("Toggle Mute", systemImage: viewModel.isMuted ? "speaker.slash": "speaker.wave.3")
+                })
+                    .buttonStyle(VideoPlayerControlsButtonStyle())
 
                 if !viewModel.isMuted {
                     Slider(value: $viewModel.volume, in: 0...100) {
@@ -75,17 +91,19 @@ struct VideoPlayerControlsView: View {
                     .controlSize(.small)
                 }
 
-                VideoPlayerControlsButtonView(title: "Change playback speed", image: viewModel.playbackRate.rawValue)
-                    .onTapGesture {
-                        switch viewModel.playbackRate {
-                        case .normal:
-                            viewModel.apply(.playbackRate(.slow))
-                        case .fast:
-                            viewModel.apply(.playbackRate(.normal))
-                        case .slow:
-                            viewModel.apply(.playbackRate(.fast))
-                        }
+                Button(action: {
+                    switch viewModel.playbackRate {
+                    case .normal:
+                        viewModel.apply(.playbackRate(.slow))
+                    case .fast:
+                        viewModel.apply(.playbackRate(.normal))
+                    case .slow:
+                        viewModel.apply(.playbackRate(.fast))
                     }
+                }, label: {
+                    Label("Change playback speed", systemImage: viewModel.playbackRate.rawValue)
+                })
+                    .buttonStyle(VideoPlayerControlsButtonStyle())
             }
         }
         .symbolVariant(.fill)
@@ -104,18 +122,17 @@ struct VideoPlayerControlsView_Previews: PreviewProvider {
 }
 
 
-struct VideoPlayerControlsButtonView: View {
-    let title: String
-    let image: String
+struct VideoPlayerControlsButtonStyle: ButtonStyle {
     @State private var isHovering: Bool = false
 
-    var body: some View {
-        Label(title, systemImage: image)
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
             .padding(6)
             .background(isHovering ? .ultraThickMaterial : .ultraThinMaterial)
             .cornerRadius(8)
             .onHover {
                 isHovering = $0
             }
+            .animation(.easeIn(duration: 0.10), value: isHovering)
     }
 }

--- a/NativeYoutube/Views/SharedViews/VideoPlayerControlsView.swift
+++ b/NativeYoutube/Views/SharedViews/VideoPlayerControlsView.swift
@@ -8,7 +8,8 @@
 import SwiftUI
 
 struct VideoPlayerControlsView: View {
-    @ObservedObject var viewModel: VideoPlayerControlsViewModel
+    @StateObject var viewModel: VideoPlayerControlsViewModel
+    @State var isHoveringVolume = false
 
     var body: some View {
         HStack{
@@ -26,6 +27,8 @@ struct VideoPlayerControlsView: View {
                 case .buffering:
                     ProgressView()
                         .controlSize(.small)
+                        .padding(6)
+
                 case .paused:
                     VideoPlayerControlsButtonView(title: "Play video", image: "play")
                         .onTapGesture {
@@ -60,6 +63,9 @@ struct VideoPlayerControlsView: View {
                 VideoPlayerControlsButtonView(title: "Toggle Mute", image: viewModel.isMuted ? "speaker.slash": "speaker.wave.3")
                     .onTapGesture {
                         viewModel.isMuted ? viewModel.apply(.unmuteVideo) : viewModel.apply(.muteVideo)
+                    }
+                    .onHover {
+                        isHoveringVolume = $0
                     }
                 VideoPlayerControlsButtonView(title: "Change playback speed", image: viewModel.playbackRate.rawValue)
                     .onTapGesture {

--- a/NativeYoutube/Views/SharedViews/VideoPlayerControlsView.swift
+++ b/NativeYoutube/Views/SharedViews/VideoPlayerControlsView.swift
@@ -9,7 +9,6 @@ import SwiftUI
 
 struct VideoPlayerControlsView: View {
     @StateObject var viewModel: VideoPlayerControlsViewModel
-    @State var isHoveringVolume = false
 
     var body: some View {
         HStack{
@@ -51,9 +50,12 @@ struct VideoPlayerControlsView: View {
 
             Group {
                 Text(viewModel.currentDuration)
-                Slider(value: $viewModel.seekbar, in: 0...1.0, onEditingChanged: { isSeeking in
-                    viewModel.apply(.seeking(isSeeking))
-                })
+
+                Slider(value: $viewModel.seekbar, in: 0...viewModel.endDuration) {
+                    viewModel.apply(.seeking($0))
+                }
+                .controlSize(.small)
+
                 Text(String(timeInterval: viewModel.endDuration))
             }
 
@@ -64,9 +66,15 @@ struct VideoPlayerControlsView: View {
                     .onTapGesture {
                         viewModel.isMuted ? viewModel.apply(.unmuteVideo) : viewModel.apply(.muteVideo)
                     }
-                    .onHover {
-                        isHoveringVolume = $0
+
+                if !viewModel.isMuted {
+                    Slider(value: $viewModel.volume, in: 0...100) {
+                        viewModel.apply(.changingVolume($0))
                     }
+                    .frame(width: 80)
+                    .controlSize(.small)
+                }
+
                 VideoPlayerControlsButtonView(title: "Change playback speed", image: viewModel.playbackRate.rawValue)
                     .onTapGesture {
                         switch viewModel.playbackRate {
@@ -82,6 +90,7 @@ struct VideoPlayerControlsView: View {
         }
         .symbolVariant(.fill)
         .labelStyle(.iconOnly)
+        .animation(.easeIn(duration: 0.25), value: viewModel.isMuted)
         .onAppear {
             viewModel.apply(.onAppear)
         }
@@ -99,10 +108,14 @@ struct VideoPlayerControlsButtonView: View {
     let title: String
     let image: String
     @State private var isHovering: Bool = false
+
     var body: some View {
         Label(title, systemImage: image)
             .padding(6)
             .background(isHovering ? .ultraThickMaterial : .ultraThinMaterial)
             .cornerRadius(8)
+            .onHover {
+                isHovering = $0
+            }
     }
 }


### PR DESCRIPTION
Hey!

I saw that your last issue was getting the controls to work so what I have done is create a view model that would handle setting the state for `VideoPlayerControlsView.swift`. It is able to know when it's playing, paused, when the duration changes, seekbar changes, and even allows to change the volume.

The only thing not working right now is going back to a previous video or going to the next video, mainly because there is only one video in the playlist.

I also did some tweaks in `PlayListView.swift` and some minor issues on how views were presented. i.e. there was padding on scroll view that made the design a bit eh.

Feel free to make changes or test it out. I used Input/output binding on `VideoPlayerControlsViewModel.swift` but if there is a better approach in your opinion then let me know!

#45 