### PR TITLE
Can now close a window by using `command + w`.

### DIFF
--- a/NativeYoutube.xcodeproj/project.pbxproj
+++ b/NativeYoutube.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		132F7F5D27AE244E00D0F607 /* KeyWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 132F7F5C27AE244E00D0F607 /* KeyWindow.swift */; };
 		13E02D0A27ABB35E00B4A648 /* VideoPlayerControlsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13E02D0927ABB35E00B4A648 /* VideoPlayerControlsViewModel.swift */; };
 		13E02D0C27ABD2FE00B4A648 /* String+Time.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13E02D0B27ABD2FE00B4A648 /* String+Time.swift */; };
 		C27DD350272C853E00B4DC16 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C27DD34F272C853E00B4DC16 /* ContentView.swift */; };
@@ -51,6 +52,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		132F7F5C27AE244E00D0F607 /* KeyWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyWindow.swift; sourceTree = "<group>"; };
 		13E02D0927ABB35E00B4A648 /* VideoPlayerControlsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoPlayerControlsViewModel.swift; sourceTree = "<group>"; };
 		13E02D0B27ABD2FE00B4A648 /* String+Time.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Time.swift"; sourceTree = "<group>"; };
 		C27DD34A272C853E00B4DC16 /* NativeYoutube.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = NativeYoutube.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -171,6 +173,7 @@
 				C27DD367272C85F900B4DC16 /* StatusBarController.swift */,
 				C27DD365272C85E400B4DC16 /* EventMonitor.swift */,
 				C27DD39C272CA96700B4DC16 /* DateConverter.swift */,
+				132F7F5C27AE244E00D0F607 /* KeyWindow.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -362,6 +365,7 @@
 				C27DD36E272C8A3400B4DC16 /* PlayListModel.swift in Sources */,
 				C27DD3AC272CBA5800B4DC16 /* NSViewRepresentable+Extension.swift in Sources */,
 				C294A6FD272E267500DD5E73 /* AudioPlayerControlsView.swift in Sources */,
+				132F7F5D27AE244E00D0F607 /* KeyWindow.swift in Sources */,
 				C27DD3A6272CADE500B4DC16 /* SearchedVideosView.swift in Sources */,
 				C294A6FF272E26AB00DD5E73 /* Utility.swift in Sources */,
 				C27DD39B272CA54A00B4DC16 /* SearchViewModel.swift in Sources */,
@@ -613,7 +617,7 @@
 			repositoryURL = "https://github.com/SvenTiigi/YouTubePlayerKit.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 1.0.0;
+				minimumVersion = 1.1.9;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/NativeYoutube.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/NativeYoutube.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/SvenTiigi/YouTubePlayerKit.git",
         "state": {
           "branch": null,
-          "revision": "12b2dfd368e0407f07407527ad24ecd9a238e2b1",
-          "version": "1.1.4"
+          "revision": "1f78a2121f58b393bca54bc0a8da9e9b11cab198",
+          "version": "1.1.9"
         }
       }
     ]

--- a/NativeYoutube/Extensions/View+Extension.swift
+++ b/NativeYoutube/Extensions/View+Extension.swift
@@ -9,31 +9,34 @@ import SwiftUI
 import Cocoa
 
 extension View {
-    private func newWindowInternal(with title: String, isTransparent: Bool?) -> NSWindow {
-        let window = NSWindow(
+    private func newWindowInternal(with title: String, isTransparent: Bool = false) -> NSWindow {
+        let window = KeyWindow(
             contentRect: NSRect(x: 20, y: 20, width: 680, height: 600),
             styleMask: [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView],
             backing: .buffered,
-            defer: false)
-        window.becomeKey()
+            defer: false
+        )
+
+        window.makeKey()
         window.isReleasedWhenClosed = false
         window.title = title
         window.makeKeyAndOrderFront(self)
         window.level = .floating
-        if let isTransparent = isTransparent{
-            if isTransparent{
-                window.backgroundColor =  .clear
-                window.isOpaque = false
-                window.styleMask = [.hudWindow, .closable]
-                window.isMovableByWindowBackground = true
-                window.makeKeyAndOrderFront(self)
-            }
+        if isTransparent{
+            window.backgroundColor =  .clear
+            window.isOpaque = false
+            window.styleMask = [.hudWindow, .closable]
+            window.isMovableByWindowBackground = true
+            window.makeKeyAndOrderFront(self)
         }
         window.setIsVisible(true)
         return window
     }
-    
-    func openNewWindow(with title: String = "New Window",  isTransparent: Bool?) {
-        self.newWindowInternal(with: title, isTransparent: isTransparent).contentView = NSHostingView(rootView: self)
+
+    func openNewWindow(with title: String = "New Window",  isTransparent: Bool = false) {
+        let window = newWindowInternal(with: title, isTransparent: isTransparent)
+        window.contentView = NSHostingView(rootView: self)
+        NSApp.activate(ignoringOtherApps: true)
+        window.makeKeyAndOrderFront(self)
     }
 }

--- a/NativeYoutube/Helpers/KeyWindow.swift
+++ b/NativeYoutube/Helpers/KeyWindow.swift
@@ -1,0 +1,31 @@
+//
+//  KeyWindow.swift
+//  NativeYoutube
+//
+//  Created by Erik Bautista on 2/4/22.
+//
+
+import AppKit
+
+
+class KeyWindow: NSWindow {
+    // This fixes issue when cannot set key window
+    // when dynamically creating via SwiftUI
+
+    override var canBecomeKey: Bool {
+        return true
+    }
+}
+
+// Handle key events
+
+extension KeyWindow {
+    override func keyDown(with event: NSEvent) {
+        if event.modifierFlags.intersection(.deviceIndependentFlagsMask) == .command && event.charactersIgnoringModifiers == "w" {
+            close()
+            return
+        } else {
+            super.keyDown(with: event)
+        }
+    }
+}

--- a/NativeYoutube/Views/SharedViews/PopupPlayerView.swift
+++ b/NativeYoutube/Views/SharedViews/PopupPlayerView.swift
@@ -10,13 +10,36 @@ import YouTubePlayerKit
 
 struct PopupPlayerView: View {
     let youtubePlayer: YouTubePlayer
+    @State var isHoveringOnPlayer = false
+
     var body: some View {
-        VStack{
-            VideoPlayerView(youtubePlayer: youtubePlayer)
-                .cornerRadius(20)
-            VideoPlayerControlsView(viewModel: .init(youtubePlayer: youtubePlayer))
-                .padding(.horizontal)
-                .padding(.bottom, 5)
+        ZStack(alignment: .topLeading) {
+            VStack{
+                VideoPlayerView(youtubePlayer: youtubePlayer)
+                    .cornerRadius(20)
+                    .onHover { hovering in
+                        withAnimation {
+                            isHoveringOnPlayer = hovering
+                        }
+                    }
+
+                VideoPlayerControlsView(viewModel: .init(youtubePlayer: youtubePlayer))
+                    .padding(.horizontal)
+                    .padding(.bottom, 5)
+            }
+
+            if isHoveringOnPlayer {
+                Button(role: .cancel) {
+                    NSApp.keyWindow?.close()
+                } label: {
+                    Label("Close", systemImage: "xmark")
+                        .labelStyle(.iconOnly)
+                        .foregroundColor(.secondary)
+                }
+                .background(.ultraThickMaterial)
+                .frame(width: 28, height: 28)
+                .offset(x: 28/2, y: 28/2)
+            }
         }
         .background(.ultraThinMaterial)
         .cornerRadius(20)


### PR DESCRIPTION
- Also fixed issue where window was not setting as key window.

I couldn't add a close button as of now because we need to reference the `NSWindow` that was created when `PopupPlayerView.swift`. 

~~Using `NSApplication.shared.keyWindow` closed the wrong windows but I will try again once I push a refactored version of `NativeYoutube`.~~

Just kidding, after overriding `canKeyWindow` to true, it properly closes the window.